### PR TITLE
fix(jdbc): corregir compilación del módulo

### DIFF
--- a/00-JDBC/00-jdbc/src/main/java/app/DAO/ProductoDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/DAO/ProductoDAO.java
@@ -1,7 +1,7 @@
 package app.DAO;
 
-import java.sql.Connection;
-import app.entidades.Producto;
+import app.DTO.ProductoDTO;
+import app.Entidades.Producto;
 
 
 public interface ProductoDAO {

--- a/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
@@ -250,13 +250,10 @@ public class DBInitializer {
                 int cantidad =
                         Integer.parseInt(record.get("cantidad"));
 
-                dao.create(
-                        new FacturaProducto(
-                                idFactura,
-                                idProducto,
-                                cantidad
-                        )
-                );
+                boolean created = dao.create(new FacturaProducto(idFactura, idProducto, cantidad));
+                if (!created) {
+                    throw new SQLException("No se pudo insertar FacturaProducto idFactura=" + idFactura + ", idProducto=" + idProducto);
+                }
             }
         }
     }

--- a/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
@@ -5,6 +5,9 @@ import app.DAO.FacturaDAO;
 import app.DAO.FacturaProductoDAO;
 import app.DAO.ProductoDAO;
 import app.Factory.DAOFactory;
+import app.Entidades.Cliente;
+import app.Entidades.FacturaProducto;
+import app.Entidades.Producto;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
@@ -105,11 +108,6 @@ public class DBInitializer {
             String pathFacturaProducto)
             throws SQLException, IOException {
 
-        ClienteDAO clienteDAO = clienteDAO;
-        FacturaDAO facturaDAO = facturaDAO();
-        ProductoDAO productoDAO = productoDAO();
-        FacturaProductoDAO facturaProductoDAO = facturaProductoDAO();
-
         // El orden es importante por las claves foráneas.
         loadClientes(clienteDAO, pathCliente);
         loadProductos(productoDAO, pathProducto);
@@ -146,10 +144,12 @@ public class DBInitializer {
                 String email =
                         record.get("Email");
 
-                dao.insert(
-                        idCliente,
-                        nombre,
-                        email
+                dao.create(
+                        new Cliente(
+                                (long) idCliente,
+                                nombre,
+                                email
+                        )
                 );
             }
         }
@@ -181,10 +181,13 @@ public class DBInitializer {
                 float valor =
                         Float.parseFloat(record.get("valor"));
 
-                dao.insert(
-                        idProducto,
-                        nombre,
-                        valor
+                dao.insertProducto(
+                        new Producto(
+                                idProducto,
+                                nombre,
+                                valor,
+                                0
+                        )
                 );
             }
         }
@@ -213,9 +216,9 @@ public class DBInitializer {
                 int idCliente =
                         Integer.parseInt(record.get("idCliente"));
 
-                dao.insert(
-                        idFactura,
-                        idCliente
+                dao.createFactura(
+                        (long) idFactura,
+                        (long) idCliente
                 );
             }
         }
@@ -247,14 +250,15 @@ public class DBInitializer {
                 int cantidad =
                         Integer.parseInt(record.get("cantidad"));
 
-                dao.insert(
-                        idFactura,
-                        idProducto,
-                        cantidad
+                dao.create(
+                        new FacturaProducto(
+                                idFactura,
+                                idProducto,
+                                cantidad
+                        )
                 );
             }
         }
     }
 }
-
 

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLClienteDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLClienteDAO.java
@@ -35,12 +35,12 @@ public class MYSQLClienteDAO implements ClienteDAO {
 
     @Override
     public Cliente findByIdCliente(Long idCliente) {
-        return null;
+        throw new UnsupportedOperationException("findByIdCliente no implementado");
     }
 
     @Override
     public List<Cliente> findAllClientes() {
-        return List.of();
+        throw new UnsupportedOperationException("findAllClientes no implementado");
     }
 
     @Override

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLClienteDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLClienteDAO.java
@@ -5,6 +5,7 @@ import app.Entidades.Cliente;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.List;
 
 public class MYSQLClienteDAO implements ClienteDAO {
 
@@ -31,4 +32,30 @@ public class MYSQLClienteDAO implements ClienteDAO {
     }
 
     //agregar metodos faltantes para conseguir los datos */
+
+    @Override
+    public Cliente findByIdCliente(Long idCliente) {
+        return null;
+    }
+
+    @Override
+    public List<Cliente> findAllClientes() {
+        return List.of();
+    }
+
+    @Override
+    public void create(Cliente c) {
+    }
+
+    @Override
+    public void update(Cliente c) {
+    }
+
+    @Override
+    public void delete(Long idCliente) {
+    }
+
+    @Override
+    public void deleteAll() {
+    }
 }

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
@@ -1,6 +1,8 @@
 package app.Factory.MYSQLEntityDAO;
 
 import app.DAO.ProductoDAO;
+import app.DTO.ProductoDTO;
+import app.Entidades.Producto;
 
 import java.sql.Connection;
 
@@ -27,4 +29,18 @@ public class MYSQLProductoDAO implements ProductoDAO {
     statement.executeUpdate();
     }
     */
+
+    @Override
+    public void insertProducto(Producto producto) {
+    }
+
+    @Override
+    public ProductoDTO getProdMasRecaudado() {
+        return null;
+    }
+
+    @Override
+    public ProductoDTO findById(int id) {
+        return null;
+    }
 }

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
@@ -32,6 +32,7 @@ public class MYSQLProductoDAO implements ProductoDAO {
 
     @Override
     public void insertProducto(Producto producto) {
+        throw new UnsupportedOperationException("insertProducto no implementado");
     }
 
     @Override


### PR DESCRIPTION
## Resumen
Este PR corrige los errores de compilación actuales en `00-JDBC/00-jdbc` para destrabar el módulo JDBC sin completar todavía la lógica funcional pendiente del TP.

## Cambios
- corrige imports y tipos en `ProductoDAO`
- elimina código inválido en `DBInitializer.loadData(...)`
- ajusta llamadas del loader para usar métodos ya declarados por los DAO
- agrega stubs mínimos en `MYSQLClienteDAO` y `MYSQLProductoDAO` para cumplir sus interfaces

## Alcance
Se limitaron los cambios a lo estrictamente necesario para que el módulo compile.

## Validación
- `mvn compile` sobre `00-JDBC/00-jdbc`

Closes #16