### PR TITLE
refactor(jdbc): alinear contratos DAO

### DIFF
--- a/00-JDBC/00-jdbc/src/main/java/app/DAO/FacturaDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/DAO/FacturaDAO.java
@@ -7,12 +7,7 @@ public interface FacturaDAO {
     Factura getFacturaById(Long idFactura);
     List<Factura> getFacturaByClienteId(Long idCliente);
     List<Factura> getAllFacturas();
-    void insertFactura(Factura factura);
+    void create(Factura factura);
     void updateFactura(Factura factura);
     void deleteFactura(Long idFactura);
-    void createFactura(Long idFactura, Long idCliente);
-
-
-
 }
-

--- a/00-JDBC/00-jdbc/src/main/java/app/DAO/ProductoDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/DAO/ProductoDAO.java
@@ -6,7 +6,7 @@ import app.Entidades.Producto;
 
 public interface ProductoDAO {
 
-    void insertProducto(Producto producto);
+    void create(Producto producto);
     ProductoDTO getProdMasRecaudado();
     ProductoDTO findById(int id);
 

--- a/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Data/DBInitializer.java
@@ -4,8 +4,8 @@ import app.DAO.ClienteDAO;
 import app.DAO.FacturaDAO;
 import app.DAO.FacturaProductoDAO;
 import app.DAO.ProductoDAO;
-import app.Factory.DAOFactory;
 import app.Entidades.Cliente;
+import app.Entidades.Factura;
 import app.Entidades.FacturaProducto;
 import app.Entidades.Producto;
 
@@ -181,7 +181,7 @@ public class DBInitializer {
                 float valor =
                         Float.parseFloat(record.get("valor"));
 
-                dao.insertProducto(
+                dao.create(
                         new Producto(
                                 idProducto,
                                 nombre,
@@ -216,9 +216,11 @@ public class DBInitializer {
                 int idCliente =
                         Integer.parseInt(record.get("idCliente"));
 
-                dao.createFactura(
-                        (long) idFactura,
-                        (long) idCliente
+                dao.create(
+                        new Factura(
+                                (long) idFactura,
+                                (long) idCliente
+                        )
                 );
             }
         }
@@ -258,4 +260,3 @@ public class DBInitializer {
         }
     }
 }
-

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLFacturaDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLFacturaDAO.java
@@ -81,7 +81,7 @@ public class MYSQLFacturaDAO implements FacturaDAO {
     }
 
     @Override
-    public void insertFactura(Factura factura) {
+    public void create(Factura factura) {
         String sql = "INSERT INTO Factura (idFactura, idCliente) VALUES (?, ?)";
 
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
@@ -121,18 +121,5 @@ public class MYSQLFacturaDAO implements FacturaDAO {
         }
     }
 
-    @Override
-    public void createFactura(Long idFactura, Long idCliente) {
-        String sql = "INSERT INTO Factura (idFactura, idCliente) VALUES (?, ?)";
-
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
-            ps.setLong(1, idFactura);
-            ps.setLong(2, idCliente);
-            ps.executeUpdate();
-        } catch (SQLException e) {
-            System.err.println("error al insertar la factura: "+e.getMessage());
-        }
-    }
 }
-
 

--- a/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
+++ b/00-JDBC/00-jdbc/src/main/java/app/Factory/MYSQLEntityDAO/MYSQLProductoDAO.java
@@ -31,8 +31,8 @@ public class MYSQLProductoDAO implements ProductoDAO {
     */
 
     @Override
-    public void insertProducto(Producto producto) {
-        throw new UnsupportedOperationException("insertProducto no implementado");
+    public void create(Producto producto) {
+        throw new UnsupportedOperationException("create no implementado");
     }
 
     @Override


### PR DESCRIPTION
## Resumen
Este PR unifica la convención de altas del módulo `00-JDBC/00-jdbc` para usar `create(Entidad)` en los DAO que todavía mezclaban variantes distintas.

## Cambios
- `ProductoDAO` pasa de `insertProducto(Producto)` a `create(Producto)`
- `FacturaDAO` pasa a usar `create(Factura)` y elimina variantes duplicadas
- `MYSQLProductoDAO` y `MYSQLFacturaDAO` se ajustan a la nueva firma
- `DBInitializer` actualiza las llamadas del loader para usar `create(...)`

## Alcance
Se unifica solo la convención de altas; no se tocan las consultas de negocio.

## Validación
- `mvn test -q` sobre `00-JDBC/00-jdbc`

Closes #18